### PR TITLE
Remove unncessary call to repaint(). Fixes crash on drop.

### DIFF
--- a/Source/DraggableListBox.cpp
+++ b/Source/DraggableListBox.cpp
@@ -54,7 +54,6 @@ void DraggableListBoxItem::hideInsertLines()
 {
     insertBefore = false;
     insertAfter = false;
-    repaint();
 }
 
 void DraggableListBoxItem::itemDragEnter(const SourceDetails& dragSourceDetails)


### PR DESCRIPTION
Without this fix I get regular crashes on drop. I think this is because we're trying to repaint an item that has been deleted.